### PR TITLE
refactor: avoid HKDF PRK re-import on subsequent Expand calls

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2323,6 +2323,16 @@ function ab(input: Uint8Array): ArrayBuffer {
   return input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength)
 }
 
+async function cacheValue<K extends object, V>(
+  cache: WeakMap<K, V>,
+  key: K,
+  init: () => Promise<V>,
+): Promise<V> {
+  const result = await init()
+  cache.set(key, result)
+  return result
+}
+
 function HKDF_SHARED(): KDF_BASE {
   let emptySalt: CryptoKey | undefined
   async function importKey(this: HKDF, salt: ArrayBuffer): Promise<CryptoKey> {
@@ -2331,12 +2341,7 @@ function HKDF_SHARED(): KDF_BASE {
       this.name,
     )
   }
-  // The key schedule expands the same PRK several times (key/base_nonce/exporter),
-  // often concurrently, so memoise the imported HMAC key per PRK — like the
-  // AEAD_SHARED cache above, but storing the in-flight promise so concurrent
-  // expands of one PRK share a single importKey. WeakMap-keyed so the entry is
-  // reclaimed once the PRK Uint8Array is unreachable.
-  const prkKeyCache = new WeakMap<Uint8Array, Promise<CryptoKey>>()
+  const cache = new WeakMap<Uint8Array, CryptoKey>()
   return {
     stages: 2,
     Derive: NotApplicable,
@@ -2356,15 +2361,8 @@ function HKDF_SHARED(): KDF_BASE {
         throw new Error('L must be <= 255*Nh')
       }
       const N = Math.ceil(L / this.Nh)
-      let keyPromise = prkKeyCache.get(_prk)
-      if (keyPromise === undefined) {
-        keyPromise = subtle(
-          (c) => c.importKey('raw', ab(_prk), { name: 'HMAC', hash: this.hash }, false, ['sign']),
-          this.name,
-        )
-        prkKeyCache.set(_prk, keyPromise)
-      }
-      const key = await keyPromise
+      const key =
+        cache.get(_prk) ?? (await cacheValue(cache, _prk, () => importKey.call(this, ab(_prk))))
 
       const T = new Uint8Array(N * this.Nh)
       let T_prev = new Uint8Array()
@@ -3619,19 +3617,18 @@ function AEAD_SHARED(): AEAD_BASE {
   const cache = new WeakMap<Uint8Array, CryptoKey>()
   async function importKey(this: WebCryptoAEAD, _key: Uint8Array): Promise<CryptoKey> {
     const key = ab(_key)
-    const cryptoKey = await subtle(
+    return await subtle(
       (c) => c.importKey(this.keyFormat, key, this.algorithm, false, ['encrypt', 'decrypt']),
       this.name,
     )
-    cache.set(_key, cryptoKey)
-    return cryptoKey
   }
   return {
     async Seal(this: WebCryptoAEAD, _key, _nonce, _aad, _pt) {
       const nonce = ab(_nonce)
       const aad = ab(_aad)
       const pt = ab(_pt)
-      const cryptoKey = cache.get(_key) ?? (await importKey.call(this, _key))
+      const cryptoKey =
+        cache.get(_key) ?? (await cacheValue(cache, _key, () => importKey.call(this, _key)))
       return new Uint8Array(
         await subtle(
           (c) => c.encrypt({ name: this.algorithm, iv: nonce, additionalData: aad }, cryptoKey, pt),
@@ -3643,7 +3640,8 @@ function AEAD_SHARED(): AEAD_BASE {
       const nonce = ab(_nonce)
       const aad = ab(_aad)
       const ct = ab(_ct)
-      const cryptoKey = cache.get(_key) ?? (await importKey.call(this, _key))
+      const cryptoKey =
+        cache.get(_key) ?? (await cacheValue(cache, _key, () => importKey.call(this, _key)))
       return new Uint8Array(
         await subtle(
           (c) => c.decrypt({ name: this.algorithm, iv: nonce, additionalData: aad }, cryptoKey, ct),

--- a/index.ts
+++ b/index.ts
@@ -2331,6 +2331,12 @@ function HKDF_SHARED(): KDF_BASE {
       this.name,
     )
   }
+  // The key schedule expands the same PRK several times (key/base_nonce/exporter),
+  // often concurrently, so memoise the imported HMAC key per PRK — like the
+  // AEAD_SHARED cache above, but storing the in-flight promise so concurrent
+  // expands of one PRK share a single importKey. WeakMap-keyed so the entry is
+  // reclaimed once the PRK Uint8Array is unreachable.
+  const prkKeyCache = new WeakMap<Uint8Array, Promise<CryptoKey>>()
   return {
     stages: 2,
     Derive: NotApplicable,
@@ -2350,11 +2356,15 @@ function HKDF_SHARED(): KDF_BASE {
         throw new Error('L must be <= 255*Nh')
       }
       const N = Math.ceil(L / this.Nh)
-      const prk = ab(_prk)
-      const key = await subtle(
-        (c) => c.importKey('raw', prk, { name: 'HMAC', hash: this.hash }, false, ['sign']),
-        this.name,
-      )
+      let keyPromise = prkKeyCache.get(_prk)
+      if (keyPromise === undefined) {
+        keyPromise = subtle(
+          (c) => c.importKey('raw', ab(_prk), { name: 'HMAC', hash: this.hash }, false, ['sign']),
+          this.name,
+        )
+        prkKeyCache.set(_prk, keyPromise)
+      }
+      const key = await keyPromise
 
       const T = new Uint8Array(N * this.Nh)
       let T_prev = new Uint8Array()

--- a/index.ts
+++ b/index.ts
@@ -2341,7 +2341,12 @@ function HKDF_SHARED(): KDF_BASE {
       this.name,
     )
   }
-  const cache = new WeakMap<Uint8Array, CryptoKey>()
+  const cache = new WeakMap<Uint8Array, Promise<CryptoKey>>()
+  function importPrk(this: HKDF, prk: Uint8Array): Promise<CryptoKey> {
+    const key = importKey.call(this, ab(prk))
+    cache.set(prk, key)
+    return key
+  }
   return {
     stages: 2,
     Derive: NotApplicable,
@@ -2361,8 +2366,7 @@ function HKDF_SHARED(): KDF_BASE {
         throw new Error('L must be <= 255*Nh')
       }
       const N = Math.ceil(L / this.Nh)
-      const key =
-        cache.get(_prk) ?? (await cacheValue(cache, _prk, () => importKey.call(this, ab(_prk))))
+      const key = await (cache.get(_prk) ?? importPrk.call(this, _prk))
 
       const T = new Uint8Array(N * this.Nh)
       let T_prev = new Uint8Array()


### PR DESCRIPTION
The key schedule derives the `key`, `base_nonce`, and `exporter_secret` from one secret, so it imports the same PRK as an HMAC key three times over. Cache that imported key per PRK, the way AEAD_SHARED already does for the AEAD key.

The cache holds the in-flight promise, so when those expansions run concurrently they wait on one importKey instead of each kicking off its own. An alternative is to only store resolved promises, but that does not change the result.

The test vectors pass locally.

This is similar to #36.